### PR TITLE
Update archive extract hook name so it works in newer Emacs versions.

### DIFF
--- a/autodisass-java-bytecode.el
+++ b/autodisass-java-bytecode.el
@@ -139,7 +139,7 @@ inside a jar archive, during auto-extraction."
                          (ad-java-bytecode-buffer class-file)))))
 
 ;; Add hook for automatically disassembling .class files inside jars
-(add-hook 'archive-extract-hooks
+(add-hook 'archive-extract-hook
           (lambda ()
             (let* ((components (split-string (buffer-file-name) ":"))
                    (jar-file   (car components))


### PR DESCRIPTION
Per https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-29.1#n3228 the extract-archive-hooks variables has been obsolete since Emacs 24 and has been removed in Emacs 29.1. https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-24#n2051 details the swtich from "archive-extract-hooks" to "archive-extract-hook".